### PR TITLE
[CI/CD] Add GitHub Actions CI + manual release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Test & Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - run: npm ci
+      - run: npm test
+      - run: npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Version bump type'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+jobs:
+  release:
+    name: Bump version & publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: npm ci
+      - run: npm test
+      - run: npm run build
+
+      - name: Configure git
+        run: |
+          git config user.name "Stanislav Kozachenko"
+          git config user.email "stanislav.03@list.ru"
+
+      - name: Bump version
+        run: npm version ${{ github.event.inputs.bump }} -m "release: v%s"
+
+      - name: Push tag
+        run: git push --follow-tags
+
+      - name: Publish to npm
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Adds CI pipeline and manual release workflow.

Key changes:
- `.github/workflows/ci.yml` — runs `npm ci`, `npm test`, `npm run build` on every PR to `main`; check name is `Test & Build`
- `.github/workflows/release.yml` — manual `workflow_dispatch` with `bump` input (patch/minor/major); bumps version via `npm version`, pushes tag, publishes to npm via `NPM_TOKEN` secret

Closes #2