### PR TITLE
[CLI] Add `claude-hook run` for TypeScript hooks without compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Claude Code invokes your script as a subprocess and pipes a JSON event to stdin.
 
 ## Quick start
 
-1. Create `.claude/hooks/index.js` (or compile a `.ts` file):
+1. Create `.claude/hooks/index.ts`:
 
 ```ts
 import { createHook } from 'claude-hook'
@@ -61,7 +61,7 @@ hook.run()
     "PreToolUse": [
       {
         "matcher": "Bash",
-        "hooks": [{ "type": "command", "command": "node .claude/hooks/index.js" }]
+        "hooks": [{ "type": "command", "command": "npx claude-hook run .claude/hooks/index.ts" }]
       }
     ]
   }

--- a/bin/run.js
+++ b/bin/run.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+'use strict'
+const { spawnSync } = require('child_process')
+const path = require('path')
+
+const subcommand = process.argv[2]
+const file = process.argv[3]
+
+if (subcommand !== 'run' || !file) {
+  process.stderr.write('Usage: claude-hook run <file>\n')
+  process.exit(1)
+}
+
+let tsxCli
+try {
+  const tsxPkg = require.resolve('tsx/package.json')
+  // tsx bin entry: "tsx": "dist/cli.mjs"
+  tsxCli = path.join(path.dirname(tsxPkg), 'dist', 'cli.mjs')
+} catch {
+  process.stderr.write('tsx is not found. Try reinstalling claude-hook.\n')
+  process.exit(1)
+}
+
+const result = spawnSync(process.execPath, [tsxCli, path.resolve(file)], {
+  stdio: 'inherit',
+  env: process.env,
+})
+
+process.exit(result.status ?? 1)

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,12 @@
       "name": "claude-hook",
       "version": "0.1.0",
       "license": "MIT",
+      "dependencies": {
+        "tsx": "^4.19.0"
+      },
+      "bin": {
+        "claude-hook": "bin/run.js"
+      },
       "devDependencies": {
         "@types/jest": "^29.5.14",
         "@types/node": "^22.0.0",
@@ -520,7 +526,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -537,7 +542,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -554,7 +558,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -571,7 +574,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -588,7 +590,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -605,7 +606,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -622,7 +622,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -639,7 +638,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -656,7 +654,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -673,7 +670,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -690,7 +686,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -707,7 +702,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -724,7 +718,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -741,7 +734,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -758,7 +750,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -775,7 +766,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -792,7 +782,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -809,7 +798,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -826,7 +814,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -843,7 +830,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -860,7 +846,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -877,7 +862,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -894,7 +878,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -911,7 +894,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -928,7 +910,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -945,7 +926,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2523,7 +2503,6 @@
       "version": "0.27.7",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
       "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -2712,7 +2691,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2774,6 +2752,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/glob": {
@@ -4393,6 +4383,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/resolve.exports": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
@@ -4940,6 +4939,25 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
       }
     },
     "node_modules/type-detect": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,13 @@
       "require": "./dist/index.cjs"
     }
   },
-  "files": ["dist"],
+  "bin": {
+    "claude-hook": "./bin/run.js"
+  },
+  "files": ["dist", "bin"],
+  "dependencies": {
+    "tsx": "^4.19.0"
+  },
   "scripts": {
     "build": "tsup src/index.ts --format esm,cjs --dts --clean",
     "test": "jest",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,5 +10,5 @@
     "skipLibCheck": true
   },
   "include": ["src"],
-  "exclude": ["src/__tests__"]
+  "exclude": ["src/__tests__", "bin"]
 }


### PR DESCRIPTION
Adds a CLI entry point so users can write `.ts` hook files without a separate compilation step.

Key changes:
- `bin/run.js` — `claude-hook run <file>` subcommand; resolves `tsx` from the package's own `node_modules` via `require.resolve('tsx/package.json')`, then spawns `node tsx-cli <file>` with `stdio: 'inherit'` to forward stdin/stdout/stderr and exit code intact
- `package.json` — added `bin` entry (`claude-hook`), added `tsx ^4.19.0` as a runtime dependency, added `bin/` to `files`
- `tsconfig.json` — excluded `bin/` from TypeScript compilation
- `README.md` — all examples updated from `node .claude/hooks/index.js` to `npx claude-hook run .claude/hooks/index.ts`

Closes #6