### PR TITLE
fix: yaml syntax error in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,8 @@ jobs:
           git config user.email "stanislav.03@list.ru"
 
       - name: Bump version
-        run: npm version ${{ github.event.inputs.bump }} -m "release: v%s"
+        run: |
+          npm version ${{ github.event.inputs.bump }} -m "release: v%s"
 
       - name: Push tag
         run: git push --follow-tags


### PR DESCRIPTION
Fixes YAML syntax error on line 42 - colon inside release message string broke the plain scalar. Wrapped run command in block scalar.