### PR TITLE
[Types] Generic ToolInput narrowing for PreToolUseContext and PostToolUseContext

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+bin/*.js eol=lf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,4 +68,4 @@ jobs:
             --body "Version bump after release v${{ steps.version.outputs.value }}." \
             --base main
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-hook",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-hook",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "tsx": "^4.19.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-hook",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-hook",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "tsx": "^4.19.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-hook",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "TypeScript middleware framework for Claude Code command hooks",
   "keywords": [
     "claude",
@@ -15,14 +15,14 @@
     "type": "git",
     "url": "https://github.com/stankozachenko/claude-hook.git"
   },
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
     }
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-hook",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "TypeScript middleware framework for Claude Code command hooks",
   "keywords": [
     "claude",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-hook",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "TypeScript middleware framework for Claude Code command hooks",
   "keywords": [
     "claude",

--- a/src/__tests__/context.test.ts
+++ b/src/__tests__/context.test.ts
@@ -59,7 +59,7 @@ describe('PreToolUseContext', () => {
   test('toolName and input accessors', () => {
     const ctx = new PreToolUseContext(preToolEvent)
     expect(ctx.toolName).toBe('Bash')
-    expect((ctx.input as { command: string }).command).toBe('rm -rf /tmp/foo')
+    expect(ctx.input.command).toBe('rm -rf /tmp/foo')
   })
 })
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -13,6 +13,7 @@ import type {
   ElicitationEvent,
   HookOutput,
   HookEventName,
+  ToolInput,
 } from './types.js'
 
 export class BaseContext {
@@ -38,13 +39,13 @@ export class BaseContext {
   _getOutput(): HookOutput { return this._output }
 }
 
-export class PreToolUseContext extends BaseContext {
+export class PreToolUseContext<T extends ToolInput = ToolInput> extends BaseContext {
   declare readonly event: PreToolUseEvent
 
   constructor(event: PreToolUseEvent) { super(event) }
 
   get toolName(): string { return this.event.tool_name }
-  get input(): PreToolUseEvent['tool_input'] { return this.event.tool_input }
+  get input(): T { return this.event.tool_input as T }
 
   block(reason: string): void {
     this._blocked = true
@@ -76,13 +77,13 @@ export class PreToolUseContext extends BaseContext {
   }
 }
 
-export class PostToolUseContext extends BaseContext {
+export class PostToolUseContext<T extends ToolInput = ToolInput> extends BaseContext {
   declare readonly event: PostToolUseEvent | PostToolUseFailureEvent
 
   constructor(event: PostToolUseEvent | PostToolUseFailureEvent) { super(event) }
 
   get toolName(): string { return this.event.tool_name }
-  get input(): PostToolUseEvent['tool_input'] { return this.event.tool_input }
+  get input(): T { return this.event.tool_input as T }
   get output(): unknown { return 'tool_response' in this.event ? this.event.tool_response : undefined }
   get error(): string | undefined { return 'error' in this.event ? this.event.error : undefined }
 

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -14,6 +14,10 @@ import type {
   FileChangedEvent,
   CwdChangedEvent,
   ElicitationEvent,
+  BashToolInput,
+  EditToolInput,
+  WriteToolInput,
+  ReadToolInput,
 } from './types.js'
 import {
   BaseContext,
@@ -71,6 +75,14 @@ function createContext(event: AnyEvent): BaseContext {
 export class HookHandler {
   private registrations: Registration[] = []
 
+  on(eventName: 'PreToolUse', matcher: 'Bash', handler: Handler<PreToolUseContext<BashToolInput>>): this
+  on(eventName: 'PreToolUse', matcher: 'Edit', handler: Handler<PreToolUseContext<EditToolInput>>): this
+  on(eventName: 'PreToolUse', matcher: 'Write', handler: Handler<PreToolUseContext<WriteToolInput>>): this
+  on(eventName: 'PreToolUse', matcher: 'Read', handler: Handler<PreToolUseContext<ReadToolInput>>): this
+  on(eventName: 'PostToolUse' | 'PostToolUseFailure', matcher: 'Bash', handler: Handler<PostToolUseContext<BashToolInput>>): this
+  on(eventName: 'PostToolUse' | 'PostToolUseFailure', matcher: 'Edit', handler: Handler<PostToolUseContext<EditToolInput>>): this
+  on(eventName: 'PostToolUse' | 'PostToolUseFailure', matcher: 'Write', handler: Handler<PostToolUseContext<WriteToolInput>>): this
+  on(eventName: 'PostToolUse' | 'PostToolUseFailure', matcher: 'Read', handler: Handler<PostToolUseContext<ReadToolInput>>): this
   on(eventName: 'PreToolUse' | 'PermissionRequest' | 'PermissionDenied', matcher: string, handler: Handler<PreToolUseContext>): this
   on(eventName: 'PostToolUse' | 'PostToolUseFailure', matcher: string, handler: Handler<PostToolUseContext>): this
   on(eventName: 'UserPromptSubmit' | 'UserPromptExpansion', matcher: string, handler: Handler<UserPromptSubmitContext>): this

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -71,7 +71,7 @@ function createContext(event: AnyEvent): BaseContext {
 export class HookHandler {
   private registrations: Registration[] = []
 
-  on(eventName: 'PreToolUse', matcher: string, handler: Handler<PreToolUseContext>): this
+  on(eventName: 'PreToolUse' | 'PermissionRequest' | 'PermissionDenied', matcher: string, handler: Handler<PreToolUseContext>): this
   on(eventName: 'PostToolUse' | 'PostToolUseFailure', matcher: string, handler: Handler<PostToolUseContext>): this
   on(eventName: 'UserPromptSubmit' | 'UserPromptExpansion', matcher: string, handler: Handler<UserPromptSubmitContext>): this
   on(eventName: 'Stop' | 'SubagentStop', matcher: string, handler: Handler<StopContext>): this


### PR DESCRIPTION
Fixes type errors when accessing tool-specific input properties (e.g. `ctx.input.command`) in hook handlers.

Key changes:
- `src/context.ts` — `PreToolUseContext<T extends ToolInput = ToolInput>` and `PostToolUseContext<T extends ToolInput = ToolInput>` are now generic; `get input(): T` returns the narrowed type
- `src/hook.ts` — add 8 typed overloads for `on('PreToolUse'/'PostToolUse', 'Bash'|'Edit'|'Write'|'Read', handler)` so TypeScript infers the correct input type automatically; add imports for `BashToolInput`, `EditToolInput`, `WriteToolInput`, `ReadToolInput`
- `src/__tests__/context.test.ts` — remove `as { command: string }` cast (no longer needed)
- `package.json` — fix exports: `import` → `index.mjs`, `require` → `index.js` to match actual tsup output; bump version to `0.2.0`
- `.gitattributes` — force LF endings on `bin/*.js` to prevent CRLF breakage on Linux/WSL when package is published from Windows

Closes #21