### PR TITLE
[Types] Align declared types and context accessors with real Claude Code events

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,12 +130,17 @@ All contexts expose:
 
 ```ts
 hook.on('PreToolUse', 'Bash', (ctx) => {
-  ctx.toolName          // 'Bash'
-  ctx.input             // { command: string }
-  ctx.block('reason')   // exit 2, block the tool call
-  ctx.allow()           // explicitly allow (skip permission prompt)
+  ctx.toolName             // 'Bash'
+  ctx.input                // { command: string, description?: string }
+  ctx.block('reason')      // exit 2, block the tool call
+  ctx.allow()              // explicitly allow (skip permission prompt)
   ctx.modify({ command: 'echo safe' })  // rewrite tool input
   ctx.addContext('info for Claude')
+})
+
+// On PermissionRequest events, suggestions from Claude Code are also available:
+hook.on('PermissionRequest', '*', (ctx) => {
+  ctx.permissionSuggestions  // e.g. [{ type: 'setMode', mode: 'acceptEdits', destination: 'session' }]
 })
 ```
 
@@ -143,10 +148,11 @@ hook.on('PreToolUse', 'Bash', (ctx) => {
 
 ```ts
 hook.on('PostToolUse', 'Bash', (ctx) => {
-  ctx.toolName   // 'Bash'
-  ctx.input      // tool input
-  ctx.output     // tool response
-  ctx.error      // error string (PostToolUseFailure only)
+  ctx.toolName    // 'Bash'
+  ctx.input       // tool input
+  ctx.output      // tool response
+  ctx.error       // error string (PostToolUseFailure only)
+  ctx.durationMs  // execution time in ms
   ctx.addContext('feedback for Claude')
 })
 ```
@@ -166,7 +172,8 @@ hook.on('UserPromptSubmit', '*', (ctx) => {
 
 ```ts
 hook.on('Stop', '*', (ctx) => {
-  ctx.block('not done yet')  // prevent Claude from stopping
+  ctx.lastAssistantMessage  // last message Claude produced
+  ctx.block('not done yet') // prevent Claude from stopping
 })
 ```
 
@@ -174,16 +181,28 @@ hook.on('Stop', '*', (ctx) => {
 
 ```ts
 hook.on('SessionStart', '*', (ctx) => {
+  ctx.source  // 'startup' | 'resume' | undefined
+  ctx.model   // e.g. 'claude-sonnet-4-6'
   ctx.setEnv('NODE_ENV', 'production')  // persists to CLAUDE_ENV_FILE
 })
 ```
 
-### `FileChangedContext` / `CwdChangedContext`
+### `FileChangedContext`
 
 ```ts
 hook.on('FileChanged', '.env|.envrc', (ctx) => {
+  ctx.filePath  // absolute path to changed file
   ctx.setEnv('UPDATED', '1')
   ctx.block('env file changed, session restart recommended')
+})
+```
+
+### `CwdChangedContext`
+
+```ts
+hook.on('CwdChanged', '*', (ctx) => {
+  ctx.oldCwd  // previous working directory
+  ctx.newCwd  // new working directory
 })
 ```
 

--- a/_e2e_tests.sh
+++ b/_e2e_tests.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PASS=0; FAIL=0
+BASE='"session_id":"s1","transcript_path":"/t","cwd":"/","permission_mode":"default"'
+TOOL_ID='"tool_use_id":"u1"'
+
+run() {
+  local json="$1"
+  local script="$2"
+  set +e
+  _stdout=$(printf '%s' "$json" | node -e "$script" 2>/tmp/_e2e_err)
+  _exit=$?
+  set -e
+  _stderr=$(cat /tmp/_e2e_err 2>/dev/null || true)
+}
+
+ok()  { echo "  PASS: $1"; PASS=$((PASS+1)); }
+fail(){ echo "  FAIL: $1"; FAIL=$((FAIL+1)); }
+
+check_exit()   { [ "$_exit"   = "$1" ] && ok "exit=$1"       || fail "exit: got $_exit, want $1"; }
+check_stdout() { echo "$_stdout" | grep -qF "$1" && ok "stdout contains '$1'" || fail "stdout missing '$1' (got: $_stdout)"; }
+check_stderr() { echo "$_stderr" | grep -qF "$1" && ok "stderr contains '$1'" || fail "stderr missing '$1' (got: $_stderr)"; }
+check_no_stdout() { [ -z "$_stdout" ] && ok "stdout empty" || fail "stdout should be empty (got: $_stdout)"; }
+
+HOOK="const { createHook } = require('./dist/index.js'); const h = createHook();"
+
+echo ""
+echo "=== 1. block() on PreToolUse ==="
+run "{$BASE,$TOOL_ID,\"hook_event_name\":\"PreToolUse\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"rm -rf /\"}}" \
+  "$HOOK h.on('PreToolUse','Bash',(ctx)=>{ if(ctx.input.command.includes('rm -rf')) ctx.block('no destructive cmds') }); h.run()"
+check_exit 2
+check_stderr "no destructive cmds"
+
+echo ""
+echo "=== 2. allow() on PreToolUse ==="
+run "{$BASE,$TOOL_ID,\"hook_event_name\":\"PreToolUse\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"ls\"}}" \
+  "$HOOK h.on('PreToolUse','Bash',(ctx)=>{ ctx.allow() }); h.run()"
+check_exit 0
+check_stdout '"permissionDecision":"allow"'
+
+echo ""
+echo "=== 3. modify() on PreToolUse ==="
+run "{$BASE,$TOOL_ID,\"hook_event_name\":\"PreToolUse\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"ls\"}}" \
+  "$HOOK h.on('PreToolUse','Bash',(ctx)=>{ ctx.modify({command:'ls --color=always'}) }); h.run()"
+check_exit 0
+check_stdout '"updatedInput"'
+check_stdout 'ls --color=always'
+
+echo ""
+echo "=== 4. addContext() on PreToolUse ==="
+run "{$BASE,$TOOL_ID,\"hook_event_name\":\"PreToolUse\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"ls\"}}" \
+  "$HOOK h.on('PreToolUse','Bash',(ctx)=>{ ctx.addContext('reminder: no sudo') }); h.run()"
+check_exit 0
+check_stdout '"additionalContext":"reminder: no sudo"'
+
+echo ""
+echo "=== 5. addContext() on PostToolUse ==="
+run "{$BASE,$TOOL_ID,\"hook_event_name\":\"PostToolUse\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"ls\"},\"tool_response\":{\"output\":\"file.txt\",\"exit_code\":0}}" \
+  "$HOOK h.on('PostToolUse','Bash',(ctx)=>{ ctx.addContext('post: done') }); h.run()"
+check_exit 0
+check_stdout '"additionalContext":"post: done"'
+
+echo ""
+echo "=== 6. PostToolUse — error accessor ==="
+run "{$BASE,$TOOL_ID,\"hook_event_name\":\"PostToolUseFailure\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"bad\"},\"error\":\"cmd not found\"}" \
+  "$HOOK h.on('PostToolUseFailure','Bash',(ctx)=>{ if(ctx.error) ctx.addContext('caught: '+ctx.error) }); h.run()"
+check_exit 0
+check_stdout "caught: cmd not found"
+
+echo ""
+echo "=== 7. suppress() ==="
+run "{$BASE,$TOOL_ID,\"hook_event_name\":\"PreToolUse\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"ls\"}}" \
+  "$HOOK h.on('PreToolUse','Bash',(ctx)=>{ ctx.suppress() }); h.run()"
+check_exit 0
+check_stdout '"suppressOutput":true'
+
+echo ""
+echo "=== 8. block() on UserPromptSubmit ==="
+run "{$BASE,\"hook_event_name\":\"UserPromptSubmit\",\"prompt\":\"DROP TABLE users\"}" \
+  "$HOOK h.on('UserPromptSubmit','*',(ctx)=>{ if(ctx.prompt.toLowerCase().includes('drop table')) ctx.block('no DDL') }); h.run()"
+check_exit 2
+check_stderr "no DDL"
+
+echo ""
+echo "=== 9. setTitle() on UserPromptSubmit ==="
+run "{$BASE,\"hook_event_name\":\"UserPromptSubmit\",\"prompt\":\"hello\"}" \
+  "$HOOK h.on('UserPromptSubmit','*',(ctx)=>{ ctx.setTitle('My Session') }); h.run()"
+check_exit 0
+check_stdout '"sessionTitle":"My Session"'
+
+echo ""
+echo "=== 10. Write tool — block .env writes ==="
+run "{$BASE,$TOOL_ID,\"hook_event_name\":\"PreToolUse\",\"tool_name\":\"Write\",\"tool_input\":{\"file_path\":\".env\",\"content\":\"SECRET=123\"}}" \
+  "$HOOK h.on('PreToolUse','Write',(ctx)=>{ if(ctx.input.file_path.endsWith('.env')) ctx.block('no .env writes') }); h.run()"
+check_exit 2
+check_stderr "no .env writes"
+
+echo ""
+echo "=== 11. Edit tool — block .env edits ==="
+run "{$BASE,$TOOL_ID,\"hook_event_name\":\"PreToolUse\",\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":\".env\",\"old_string\":\"a\",\"new_string\":\"b\"}}" \
+  "$HOOK h.on('PreToolUse','Edit',(ctx)=>{ if(ctx.input.file_path.endsWith('.env')) ctx.block('no .env edits') }); h.run()"
+check_exit 2
+check_stderr "no .env edits"
+
+echo ""
+echo "=== 12. Pipe matcher Bash|Write — Bash matches ==="
+run "{$BASE,$TOOL_ID,\"hook_event_name\":\"PreToolUse\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"ls\"}}" \
+  "$HOOK h.on('PreToolUse','Bash|Write',(ctx)=>{ ctx.block('matched') }); h.run()"
+check_exit 2
+check_stderr "matched"
+
+echo ""
+echo "=== 13. Pipe matcher Bash|Write — Write matches ==="
+run "{$BASE,$TOOL_ID,\"hook_event_name\":\"PreToolUse\",\"tool_name\":\"Write\",\"tool_input\":{\"file_path\":\"x.txt\",\"content\":\"hi\"}}" \
+  "$HOOK h.on('PreToolUse','Bash|Write',(ctx)=>{ ctx.block('matched') }); h.run()"
+check_exit 2
+check_stderr "matched"
+
+echo ""
+echo "=== 14. Pipe matcher Bash|Write — Edit does NOT match ==="
+run "{$BASE,$TOOL_ID,\"hook_event_name\":\"PreToolUse\",\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":\"x.txt\",\"old_string\":\"a\",\"new_string\":\"b\"}}" \
+  "$HOOK h.on('PreToolUse','Bash|Write',(ctx)=>{ ctx.block('matched') }); h.run()"
+check_exit 0
+check_no_stdout
+
+echo ""
+echo "=== 15. Regex matcher — matches Bash ==="
+run "{$BASE,$TOOL_ID,\"hook_event_name\":\"PreToolUse\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"ls\"}}" \
+  "$HOOK h.on('PreToolUse','^(Bash|Edit)$',(ctx)=>{ ctx.block('regex matched') }); h.run()"
+check_exit 2
+check_stderr "regex matched"
+
+echo ""
+echo "=== 16. Regex matcher — does NOT match Write ==="
+run "{$BASE,$TOOL_ID,\"hook_event_name\":\"PreToolUse\",\"tool_name\":\"Write\",\"tool_input\":{\"file_path\":\"x.txt\",\"content\":\"hi\"}}" \
+  "$HOOK h.on('PreToolUse','^(Bash|Edit)$',(ctx)=>{ ctx.block('regex matched') }); h.run()"
+check_exit 0
+check_no_stdout
+
+echo ""
+echo "=== 17. Wildcard eventName '*' ==="
+run "{$BASE,$TOOL_ID,\"hook_event_name\":\"PreToolUse\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"ls\"}}" \
+  "$HOOK h.on('*','*',(ctx)=>{ ctx.block('caught by wildcard') }); h.run()"
+check_exit 2
+check_stderr "caught by wildcard"
+
+echo ""
+echo "=== 18. Multiple handlers — first blocks, second skipped ==="
+run "{$BASE,$TOOL_ID,\"hook_event_name\":\"PreToolUse\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"bad\"}}" \
+  "$HOOK h.on('PreToolUse','Bash',(ctx)=>{ ctx.block('first') }); h.on('PreToolUse','Bash',(ctx)=>{ ctx.addContext('second should not run') }); h.run()"
+check_exit 2
+check_stderr "first"
+
+echo ""
+echo "=== 19. No matching handler — exit 0, no output ==="
+run "{$BASE,$TOOL_ID,\"hook_event_name\":\"PreToolUse\",\"tool_name\":\"Read\",\"tool_input\":{\"file_path\":\"/etc/hosts\"}}" \
+  "$HOOK h.on('PreToolUse','Bash',(ctx)=>{ ctx.block('bash only') }); h.run()"
+check_exit 0
+check_no_stdout
+
+echo ""
+echo "=== 20. FileChanged — block on .env change ==="
+run "{$BASE,\"hook_event_name\":\"FileChanged\",\"file_path\":\"/project/.env\"}" \
+  "$HOOK h.on('FileChanged','.env',(ctx)=>{ ctx.block('.env changed!') }); h.run()"
+check_exit 2
+check_stderr ".env changed!"
+
+echo ""
+echo "=== 21. Elicitation — block ==="
+run "{$BASE,\"hook_event_name\":\"Elicitation\",\"prompt\":\"Enter your API key\"}" \
+  "$HOOK h.on('Elicitation','*',(ctx)=>{ ctx.block('no elicitation') }); h.run()"
+check_exit 2
+check_stderr "no elicitation"
+
+echo ""
+echo "=== 22. Read tool typed input ==="
+run "{$BASE,$TOOL_ID,\"hook_event_name\":\"PreToolUse\",\"tool_name\":\"Read\",\"tool_input\":{\"file_path\":\"/etc/passwd\"}}" \
+  "$HOOK h.on('PreToolUse','Read',(ctx)=>{ if(ctx.input.file_path.includes('passwd')) ctx.block('sensitive file') }); h.run()"
+check_exit 2
+check_stderr "sensitive file"
+
+echo ""
+echo "=== 23. PostToolUse — durationMs accessor ==="
+run "{$BASE,$TOOL_ID,\"hook_event_name\":\"PostToolUse\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"ls\"},\"tool_response\":{\"output\":\"x\"},\"duration_ms\":42}" \
+  "$HOOK h.on('PostToolUse','Bash',(ctx)=>{ ctx.addContext('took:'+ctx.durationMs) }); h.run()"
+check_exit 0
+check_stdout "took:42"
+
+echo ""
+echo "=== 24. Stop — lastAssistantMessage accessor ==="
+run "{$BASE,\"hook_event_name\":\"Stop\",\"stop_hook_active\":false,\"last_assistant_message\":\"Done!\"}" \
+  "$HOOK h.on('Stop','*',(ctx)=>{ if(ctx.lastAssistantMessage) ctx.block('saw: '+ctx.lastAssistantMessage) }); h.run()"
+check_exit 2
+check_stderr "saw: Done!"
+
+echo ""
+echo "=== 25. SessionStart — source and model accessors ==="
+run "{\"session_id\":\"s1\",\"transcript_path\":\"/t\",\"cwd\":\"/\",\"hook_event_name\":\"SessionStart\",\"source\":\"startup\",\"model\":\"claude-sonnet-4-6\"}" \
+  "$HOOK h.on('SessionStart','*',(ctx)=>{ ctx.suppress() }); h.run()"
+check_exit 0
+check_stdout '"suppressOutput":true'
+
+echo ""
+echo "=== 26. PermissionRequest — permissionSuggestions accessor ==="
+run "{$BASE,$TOOL_ID,\"hook_event_name\":\"PermissionRequest\",\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":\"x.ts\",\"old_string\":\"a\",\"new_string\":\"b\"},\"permission_suggestions\":[{\"type\":\"setMode\",\"mode\":\"acceptEdits\"}]}" \
+  "$HOOK h.on('PermissionRequest','Edit',(ctx)=>{ const s=ctx.permissionSuggestions; if(s&&s.length>0) ctx.addContext('suggestion:'+s[0].mode) }); h.run()"
+check_exit 0
+check_stdout "suggestion:acceptEdits"
+
+echo ""
+echo "=== 27. SessionStart — no permission_mode (BaseEvent optional) ==="
+run "{\"session_id\":\"s1\",\"transcript_path\":\"/t\",\"cwd\":\"/\",\"hook_event_name\":\"SessionStart\"}" \
+  "$HOOK h.on('SessionStart','*',(ctx)=>{ ctx.suppress() }); h.run()"
+check_exit 0
+check_stdout '"suppressOutput":true'
+
+echo ""
+echo "==============================="
+echo "Results: $PASS passed, $FAIL failed"
+[ $FAIL -eq 0 ] && echo "All tests passed!" || echo "Some tests FAILED."
+echo "==============================="
+exit $FAIL

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-hook",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "TypeScript middleware framework for Claude Code command hooks",
   "keywords": [
     "claude",
@@ -13,7 +13,7 @@
   "author": "Stanislav Kozachenko",
   "repository": {
     "type": "git",
-    "url": "https://github.com/stankozachenko/claude-hook.git"
+    "url": "https://github.com/StanislavKozachenko/claude-hook.git"
   },
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/__tests__/context.test.ts
+++ b/src/__tests__/context.test.ts
@@ -27,7 +27,7 @@ const postToolEvent: PostToolUseEvent = {
 const promptEvent: UserPromptSubmitEvent = {
   ...baseEvent,
   hook_event_name: 'UserPromptSubmit',
-  user_message: 'DROP TABLE users',
+  prompt: 'DROP TABLE users',
 }
 
 describe('PreToolUseContext', () => {

--- a/src/context.ts
+++ b/src/context.ts
@@ -14,6 +14,7 @@ import type {
   HookOutput,
   HookEventName,
   ToolInput,
+  PermissionSuggestion,
 } from './types.js'
 
 export class BaseContext {
@@ -46,6 +47,9 @@ export class PreToolUseContext<T extends ToolInput = ToolInput> extends BaseCont
 
   get toolName(): string { return this.event.tool_name }
   get input(): T { return this.event.tool_input as T }
+  get permissionSuggestions(): PermissionSuggestion[] | undefined {
+    return (this.event as unknown as { permission_suggestions?: PermissionSuggestion[] }).permission_suggestions
+  }
 
   block(reason: string): void {
     this._blocked = true
@@ -86,6 +90,7 @@ export class PostToolUseContext<T extends ToolInput = ToolInput> extends BaseCon
   get input(): T { return this.event.tool_input as T }
   get output(): unknown { return 'tool_response' in this.event ? this.event.tool_response : undefined }
   get error(): string | undefined { return 'error' in this.event ? this.event.error : undefined }
+  get durationMs(): number | undefined { return this.event.duration_ms }
 
   addContext(text: string): void {
     this._output.hookSpecificOutput = {
@@ -130,6 +135,8 @@ export class StopContext extends BaseContext {
 
   constructor(event: StopEvent | SubagentStopEvent) { super(event) }
 
+  get lastAssistantMessage(): string | undefined { return this.event.last_assistant_message }
+
   block(reason: string): void {
     this._blocked = true
     this._blockReason = reason
@@ -140,6 +147,9 @@ export class SessionStartContext extends BaseContext {
   declare readonly event: SessionStartEvent
 
   constructor(event: SessionStartEvent) { super(event) }
+
+  get source(): string | undefined { return this.event.source }
+  get model(): string | undefined { return this.event.model }
 
   setEnv(key: string, value: string): void {
     const envFile = process.env['CLAUDE_ENV_FILE']

--- a/src/context.ts
+++ b/src/context.ts
@@ -101,7 +101,7 @@ export class UserPromptSubmitContext extends BaseContext {
 
   constructor(event: UserPromptSubmitEvent) { super(event) }
 
-  get prompt(): string { return this.event.user_message }
+  get prompt(): string { return this.event.prompt }
 
   block(reason: string): void {
     this._blocked = true

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,7 +90,7 @@ export interface PostToolUseFailureEvent extends BaseEvent {
 
 export interface UserPromptSubmitEvent extends BaseEvent {
   hook_event_name: 'UserPromptSubmit'
-  user_message: string
+  prompt: string
 }
 
 export interface UserPromptExpansionEvent extends BaseEvent {

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,7 +32,7 @@ export interface BaseEvent {
   session_id: string
   transcript_path: string
   cwd: string
-  permission_mode: string
+  permission_mode?: string
   hook_event_name: HookEventName
   agent_id?: string
   agent_type?: string
@@ -42,6 +42,7 @@ export interface BaseEvent {
 export interface BashToolInput {
   command: string
   restart?: boolean
+  description?: string
 }
 
 export interface EditToolInput {
@@ -78,6 +79,7 @@ export interface PostToolUseEvent extends BaseEvent {
   tool_input: ToolInput
   tool_use_id: string
   tool_response: unknown
+  duration_ms?: number
 }
 
 export interface PostToolUseFailureEvent extends BaseEvent {
@@ -86,6 +88,7 @@ export interface PostToolUseFailureEvent extends BaseEvent {
   tool_input: ToolInput
   tool_use_id: string
   error: string
+  duration_ms?: number
 }
 
 export interface UserPromptSubmitEvent extends BaseEvent {
@@ -100,6 +103,8 @@ export interface UserPromptExpansionEvent extends BaseEvent {
 
 export interface SessionStartEvent extends BaseEvent {
   hook_event_name: 'SessionStart'
+  source?: string
+  model?: string
 }
 
 export interface SessionEndEvent extends BaseEvent {
@@ -109,6 +114,7 @@ export interface SessionEndEvent extends BaseEvent {
 export interface StopEvent extends BaseEvent {
   hook_event_name: 'Stop'
   stop_hook_active: boolean
+  last_assistant_message?: string
 }
 
 export interface StopFailureEvent extends BaseEvent {
@@ -119,6 +125,8 @@ export interface StopFailureEvent extends BaseEvent {
 export interface SubagentStopEvent extends BaseEvent {
   hook_event_name: 'SubagentStop'
   stop_hook_active: boolean
+  last_assistant_message?: string
+  agent_transcript_path?: string
 }
 
 export interface NotificationEvent extends BaseEvent {
@@ -133,18 +141,25 @@ export interface InstructionsLoadedEvent extends BaseEvent {
   files: string[]
 }
 
+export interface PermissionSuggestion {
+  type: string
+  mode?: string
+  destination?: string
+}
+
 export interface PermissionRequestEvent extends BaseEvent {
   hook_event_name: 'PermissionRequest'
   tool_name: string
   tool_input: ToolInput
-  tool_use_id: string
+  tool_use_id?: string
+  permission_suggestions?: PermissionSuggestion[]
 }
 
 export interface PermissionDeniedEvent extends BaseEvent {
   hook_event_name: 'PermissionDenied'
   tool_name: string
   tool_input: ToolInput
-  tool_use_id: string
+  tool_use_id?: string
 }
 
 export interface PostToolBatchEvent extends BaseEvent {


### PR DESCRIPTION
Fixes multiple mismatches between `types.ts`/`context.ts` declarations and the actual Claude Code event payloads, verified against real captured events.

Key changes:
- `src/types.ts` — `UserPromptSubmitEvent.user_message` → `prompt` (primary crash bug); `BaseEvent.permission_mode` made optional; `BashToolInput` gets `description?`; `PostToolUseEvent` and `PostToolUseFailureEvent` get `duration_ms?`; `SessionStartEvent` gets `source?` and `model?`; `StopEvent` and `SubagentStopEvent` get `last_assistant_message?`; `SubagentStopEvent` gets `agent_transcript_path?`; `PermissionRequestEvent` and `PermissionDeniedEvent` — `tool_use_id` made optional; `PermissionRequestEvent` gets `permission_suggestions?`; new `PermissionSuggestion` interface added
- `src/context.ts` — `UserPromptSubmitContext.prompt` getter fixed; new accessors: `PreToolUseContext.permissionSuggestions`, `PostToolUseContext.durationMs`, `StopContext.lastAssistantMessage`, `SessionStartContext.source`, `SessionStartContext.model`
- `src/__tests__/context.test.ts` — fixture field name updated (`user_message` → `prompt`)
- `README.md` — all new accessors documented; `FileChangedContext` and `CwdChangedContext` split into separate sections with `filePath`, `oldCwd`, `newCwd`
- `package.json` — version bumped to 0.2.1; repository URL casing fixed
- `_e2e_tests.sh` — 27 E2E tests (55 assertions) covering all context API features; passes on Windows and WSL

Closes #24