### PR TITLE
[Chore] Fix CI and Node.js badges in README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "dist",
     "bin"
   ],
+  "engines": {
+    "node": ">=18"
+  },
   "dependencies": {
     "tsx": "^4.19.0"
   },


### PR DESCRIPTION
Fixes two README badges that were showing incorrect status after the initial badge setup.

Key changes:
- `.github/workflows/ci.yml` — adds `push: branches: [main]` trigger alongside the existing `pull_request` trigger; CI now runs on every merge to main, giving the CI badge a real status to display
- `package.json` — adds `"engines": { "node": ">=18" }` field; shields.io reads this to render the Node.js version badge correctly

Closes #29