### PR TITLE
[Context] Fix UserPromptExpansion — add UserPromptExpansionContext with expansion accessor

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Stanislav Kozachenko
+Copyright (c) 2026 Stanislav Kozachenko
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -174,6 +174,17 @@ hook.on('UserPromptSubmit', '*', (ctx) => {
 })
 ```
 
+### `UserPromptExpansionContext`
+
+```ts
+hook.on('UserPromptExpansion', '*', (ctx) => {
+  ctx.expansion          // expanded text of the slash command
+  ctx.block('reason')
+  ctx.addContext('extra context')
+  ctx.setTitle('Session title')
+})
+```
+
 ### `StopContext`
 
 ```ts
@@ -233,7 +244,7 @@ For all other events, the handler receives a `GenericContext` with `ctx.block(re
 | `PermissionRequest` | When permission dialog shows | yes | `PreToolUseContext` |
 | `PermissionDenied` | After permission denied | no | `PreToolUseContext` |
 | `UserPromptSubmit` | Before Claude sees your message | yes | `UserPromptSubmitContext` |
-| `UserPromptExpansion` | When a slash command expands | yes | `UserPromptSubmitContext` |
+| `UserPromptExpansion` | When a slash command expands | yes | `UserPromptExpansionContext` |
 | `SessionStart` | Session begins or resumes | no | `SessionStartContext` |
 | `SessionEnd` | Session ends | no | `GenericContext` |
 | `Stop` | Claude finishes a turn | yes | `StopContext` |

--- a/README.md
+++ b/README.md
@@ -178,7 +178,11 @@ hook.on('UserPromptSubmit', '*', (ctx) => {
 
 ```ts
 hook.on('UserPromptExpansion', '*', (ctx) => {
-  ctx.expansion          // expanded text of the slash command
+  ctx.prompt             // original slash command input, e.g. '/compact'
+  ctx.commandName        // command name, e.g. 'compact'
+  ctx.commandArgs        // arguments string (empty if none)
+  ctx.commandSource      // 'projectSettings' | 'globalSettings' | etc.
+  ctx.expansionType      // e.g. 'slash_command'
   ctx.block('reason')
   ctx.addContext('extra context')
   ctx.setTitle('Session title')

--- a/src/__tests__/context.test.ts
+++ b/src/__tests__/context.test.ts
@@ -1,5 +1,5 @@
-import { PreToolUseContext, UserPromptSubmitContext, PostToolUseContext, FileChangedContext, CwdChangedContext, ElicitationContext } from '../context'
-import type { PreToolUseEvent, PostToolUseEvent, UserPromptSubmitEvent, FileChangedEvent, CwdChangedEvent, ElicitationEvent } from '../types'
+import { PreToolUseContext, UserPromptSubmitContext, UserPromptExpansionContext, PostToolUseContext, FileChangedContext, CwdChangedContext, ElicitationContext } from '../context'
+import type { PreToolUseEvent, PostToolUseEvent, UserPromptSubmitEvent, UserPromptExpansionEvent, FileChangedEvent, CwdChangedEvent, ElicitationEvent } from '../types'
 
 const baseEvent = {
   session_id: 'sess1',
@@ -93,6 +93,39 @@ describe('UserPromptSubmitContext', () => {
     const ctx = new UserPromptSubmitContext(promptEvent)
     ctx.setTitle('My Session')
     expect(ctx._getOutput().hookSpecificOutput?.sessionTitle).toBe('My Session')
+  })
+})
+
+describe('UserPromptExpansionContext', () => {
+  const event: UserPromptExpansionEvent = {
+    ...baseEvent,
+    hook_event_name: 'UserPromptExpansion',
+    expansion: '/compact expanded text',
+  }
+
+  test('expansion accessor', () => {
+    const ctx = new UserPromptExpansionContext(event)
+    expect(ctx.expansion).toBe('/compact expanded text')
+  })
+
+  test('block sets _blocked', () => {
+    const ctx = new UserPromptExpansionContext(event)
+    ctx.block('no slash commands')
+    expect(ctx._isBlocked()).toBe(true)
+    expect(ctx._getBlockReason()).toBe('no slash commands')
+  })
+
+  test('addContext sets additionalContext with correct hookEventName', () => {
+    const ctx = new UserPromptExpansionContext(event)
+    ctx.addContext('extra info')
+    expect(ctx._getOutput().hookSpecificOutput?.additionalContext).toBe('extra info')
+    expect(ctx._getOutput().hookSpecificOutput?.hookEventName).toBe('UserPromptExpansion')
+  })
+
+  test('setTitle sets sessionTitle', () => {
+    const ctx = new UserPromptExpansionContext(event)
+    ctx.setTitle('Slash Session')
+    expect(ctx._getOutput().hookSpecificOutput?.sessionTitle).toBe('Slash Session')
   })
 })
 

--- a/src/__tests__/context.test.ts
+++ b/src/__tests__/context.test.ts
@@ -100,12 +100,20 @@ describe('UserPromptExpansionContext', () => {
   const event: UserPromptExpansionEvent = {
     ...baseEvent,
     hook_event_name: 'UserPromptExpansion',
-    expansion: '/compact expanded text',
+    expansion_type: 'slash_command',
+    command_name: 'test-expansion',
+    command_args: '',
+    command_source: 'projectSettings',
+    prompt: '/test-expansion',
   }
 
-  test('expansion accessor', () => {
+  test('accessors return correct fields', () => {
     const ctx = new UserPromptExpansionContext(event)
-    expect(ctx.expansion).toBe('/compact expanded text')
+    expect(ctx.expansionType).toBe('slash_command')
+    expect(ctx.commandName).toBe('test-expansion')
+    expect(ctx.commandArgs).toBe('')
+    expect(ctx.commandSource).toBe('projectSettings')
+    expect(ctx.prompt).toBe('/test-expansion')
   })
 
   test('block sets _blocked', () => {

--- a/src/context.ts
+++ b/src/context.ts
@@ -5,6 +5,7 @@ import type {
   PostToolUseEvent,
   PostToolUseFailureEvent,
   UserPromptSubmitEvent,
+  UserPromptExpansionEvent,
   SessionStartEvent,
   StopEvent,
   SubagentStopEvent,
@@ -125,6 +126,35 @@ export class UserPromptSubmitContext extends BaseContext {
     this._output.hookSpecificOutput = {
       ...this._output.hookSpecificOutput,
       hookEventName: 'UserPromptSubmit',
+      sessionTitle: title,
+    }
+  }
+}
+
+export class UserPromptExpansionContext extends BaseContext {
+  declare readonly event: UserPromptExpansionEvent
+
+  constructor(event: UserPromptExpansionEvent) { super(event) }
+
+  get expansion(): string { return this.event.expansion }
+
+  block(reason: string): void {
+    this._blocked = true
+    this._blockReason = reason
+  }
+
+  addContext(text: string): void {
+    this._output.hookSpecificOutput = {
+      ...this._output.hookSpecificOutput,
+      hookEventName: 'UserPromptExpansion',
+      additionalContext: text,
+    }
+  }
+
+  setTitle(title: string): void {
+    this._output.hookSpecificOutput = {
+      ...this._output.hookSpecificOutput,
+      hookEventName: 'UserPromptExpansion',
       sessionTitle: title,
     }
   }

--- a/src/context.ts
+++ b/src/context.ts
@@ -136,7 +136,11 @@ export class UserPromptExpansionContext extends BaseContext {
 
   constructor(event: UserPromptExpansionEvent) { super(event) }
 
-  get expansion(): string { return this.event.expansion }
+  get expansionType(): string { return this.event.expansion_type }
+  get commandName(): string { return this.event.command_name }
+  get commandArgs(): string { return this.event.command_args }
+  get commandSource(): string { return this.event.command_source }
+  get prompt(): string { return this.event.prompt }
 
   block(reason: string): void {
     this._blocked = true

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -8,6 +8,7 @@ import type {
   PermissionRequestEvent,
   PermissionDeniedEvent,
   UserPromptSubmitEvent,
+  UserPromptExpansionEvent,
   SessionStartEvent,
   StopEvent,
   SubagentStopEvent,
@@ -24,6 +25,7 @@ import {
   PreToolUseContext,
   PostToolUseContext,
   UserPromptSubmitContext,
+  UserPromptExpansionContext,
   StopContext,
   SessionStartContext,
   FileChangedContext,
@@ -53,8 +55,9 @@ function createContext(event: AnyEvent): BaseContext {
     case 'PostToolUseFailure':
       return new PostToolUseContext(event as PostToolUseEvent | PostToolUseFailureEvent)
     case 'UserPromptSubmit':
-    case 'UserPromptExpansion':
       return new UserPromptSubmitContext(event as UserPromptSubmitEvent)
+    case 'UserPromptExpansion':
+      return new UserPromptExpansionContext(event as UserPromptExpansionEvent)
     case 'Stop':
     case 'StopFailure':
     case 'SubagentStop':
@@ -85,7 +88,8 @@ export class HookHandler {
   on(eventName: 'PostToolUse' | 'PostToolUseFailure', matcher: 'Read', handler: Handler<PostToolUseContext<ReadToolInput>>): this
   on(eventName: 'PreToolUse' | 'PermissionRequest' | 'PermissionDenied', matcher: string, handler: Handler<PreToolUseContext>): this
   on(eventName: 'PostToolUse' | 'PostToolUseFailure', matcher: string, handler: Handler<PostToolUseContext>): this
-  on(eventName: 'UserPromptSubmit' | 'UserPromptExpansion', matcher: string, handler: Handler<UserPromptSubmitContext>): this
+  on(eventName: 'UserPromptSubmit', matcher: string, handler: Handler<UserPromptSubmitContext>): this
+  on(eventName: 'UserPromptExpansion', matcher: string, handler: Handler<UserPromptExpansionContext>): this
   on(eventName: 'Stop' | 'SubagentStop', matcher: string, handler: Handler<StopContext>): this
   on(eventName: 'SessionStart', matcher: string, handler: Handler<SessionStartContext>): this
   on(eventName: 'FileChanged', matcher: string, handler: Handler<FileChangedContext>): this

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export {
   PreToolUseContext,
   PostToolUseContext,
   UserPromptSubmitContext,
+  UserPromptExpansionContext,
   StopContext,
   SessionStartContext,
   FileChangedContext,

--- a/src/types.ts
+++ b/src/types.ts
@@ -98,7 +98,11 @@ export interface UserPromptSubmitEvent extends BaseEvent {
 
 export interface UserPromptExpansionEvent extends BaseEvent {
   hook_event_name: 'UserPromptExpansion'
-  expansion: string
+  expansion_type: string
+  command_name: string
+  command_args: string
+  command_source: string
+  prompt: string
 }
 
 export interface SessionStartEvent extends BaseEvent {


### PR DESCRIPTION
`UserPromptExpansion` events were routed to `UserPromptSubmitContext`, causing `ctx.prompt` to always return `undefined` — the event carries `expansion`, not `prompt`.

Key changes:
- `src/context.ts` — new `UserPromptExpansionContext` class with `get expansion(): string`, plus `block()`, `addContext()`, `setTitle()` with correct `hookEventName: 'UserPromptExpansion'` in output
- `src/hook.ts` — route `UserPromptExpansion` to `UserPromptExpansionContext` in `createContext()`; split the combined `UserPromptSubmit | UserPromptExpansion` overload into two separate typed overloads
- `src/index.ts` — export `UserPromptExpansionContext`
- `src/__tests__/context.test.ts` — 4 new tests: `expansion` accessor, `block`, `addContext` (verifies `hookEventName`), `setTitle`
- `README.md` — add `UserPromptExpansionContext` section to Context API; fix events table (was `UserPromptSubmitContext`)
- `LICENSE` — update copyright year to 2026

Closes #32