### PR TITLE
[CI] Switch npm publish to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -52,9 +53,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish to npm
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance
 
       - name: Open version bump PR
         run: |


### PR DESCRIPTION
Closes #35

- Add `id-token: write` permission to the release workflow
- Replace `npm publish` with `npm publish --provenance`
- Remove `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}`