### PR TITLE
[Docs] Add CHANGELOG.md and automate updates on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,54 @@ jobs:
         id: version
         run: echo "value=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
 
+      - name: Update CHANGELOG
+        run: |
+          VERSION="${{ steps.version.outputs.value }}"
+          DATE=$(date +%Y-%m-%d)
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+
+          get_section() {
+            local prefix=$1
+            if [ -n "$LAST_TAG" ]; then
+              git log "${LAST_TAG}..HEAD" --pretty=format:"%s" \
+                | grep -E "^${prefix}(\([^)]+\))?:" \
+                | sed -E "s/^${prefix}(\([^)]+\))?: /- /" || true
+            fi
+          }
+
+          ADDED=$(get_section "feat")
+          FIXED=$(get_section "fix")
+
+          {
+            echo "## [${VERSION}] - ${DATE}"
+            echo ""
+            if [ -n "$ADDED" ]; then
+              echo "### Added"
+              echo ""
+              echo "$ADDED"
+              echo ""
+            fi
+            if [ -n "$FIXED" ]; then
+              echo "### Fixed"
+              echo ""
+              echo "$FIXED"
+              echo ""
+            fi
+            echo "---"
+            echo ""
+          } > /tmp/changelog-entry.md
+
+          python3 - <<'PYEOF'
+          with open('CHANGELOG.md', 'r') as f:
+              content = f.read()
+          with open('/tmp/changelog-entry.md', 'r') as f:
+              entry = f.read()
+          idx = content.index('---\n') + 4
+          content = content[:idx] + '\n' + entry + content[idx:]
+          with open('CHANGELOG.md', 'w') as f:
+              f.write(content)
+          PYEOF
+
       - name: Create GitHub release
         run: gh release create "v${{ steps.version.outputs.value }}" --title "v${{ steps.version.outputs.value }}" --generate-notes
         env:
@@ -59,7 +107,7 @@ jobs:
         run: |
           BRANCH="release/v${{ steps.version.outputs.value }}"
           git checkout -b "$BRANCH"
-          git add package.json package-lock.json
+          git add package.json package-lock.json CHANGELOG.md
           git commit -m "chore: bump version to ${{ steps.version.outputs.value }}"
           git push origin "$BRANCH"
           gh pr create \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,80 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+---
+
+## [0.2.4] - 2026-04-28
+
+### Added
+
+- `UserPromptExpansionContext` — dedicated context for `UserPromptExpansion` events with `expansionType`, `commandName`, `commandArgs`, `commandSource`, and `prompt` accessors
+
+### Fixed
+
+- `UserPromptExpansionEvent` fields corrected to match real Claude Code events — was incorrectly typed as `{ expansion: string }`, actual fields are `expansion_type`, `command_name`, `command_args`, `command_source`, `prompt`
+- LICENSE year updated to 2026
+
+---
+
+## [0.2.3] - 2026-04-28
+
+### Fixed
+
+- CI badge now triggers on `push` to `main`
+- Node.js badge now sources version from the `engines` field in package.json
+
+---
+
+## [0.2.2] - 2026-04-28
+
+### Added
+
+- README badges: npm version, downloads, CI status, license, Node.js version
+
+### Fixed
+
+- CI workflow now triggers on version bump PRs
+- Removed unused `e2e` npm script
+
+---
+
+## [0.2.1] - 2026-04-28
+
+### Fixed
+
+- `UserPromptSubmitEvent.prompt` field name corrected — Claude Code sends `prompt`, not `message`; `ctx.prompt` was always `undefined`
+- Event type fields aligned with live Claude Code events; all context accessors verified with E2E tests
+
+---
+
+## [0.2.0] - 2026-04-27
+
+### Fixed
+
+- `PermissionRequest` and `PermissionDenied` events now route to `PreToolUseContext` — `ctx.toolName`, `ctx.input`, `ctx.allow()`, `ctx.block()` are now available for these events
+- Package exports corrected to match actual tsup output filenames (`dist/index.js`, `dist/index.cjs`)
+- `ToolInput` generics narrowed for typed `ctx.input` access per tool
+
+---
+
+## [0.1.1] - 2026-04-27
+
+### Fixed
+
+- YAML syntax error in release workflow version bump step
+- Release workflow rewritten to push directly then open a version bump PR, avoiding branch protection conflicts
+
+---
+
+## [0.1.0] - 2026-04-27
+
+### Added
+
+- `createHook()` / `hook.on(eventName, matcher, handler)` / `hook.run()` — TypeScript middleware API for Claude Code hooks
+- Context classes: `PreToolUseContext`, `PostToolUseContext`, `UserPromptSubmitContext`, `StopContext`, `SessionStartContext`, `FileChangedContext`, `CwdChangedContext`, `ElicitationContext`, `GenericContext`
+- Full event type definitions for all 26+ Claude Code hook events
+- `claude-hook run <script>` CLI — runs TypeScript hook scripts via `tsx` without a build step
+- CI workflow and manual release pipeline with `patch` / `minor` / `major` input


### PR DESCRIPTION
Closes #36

- Add `CHANGELOG.md` following Keep a Changelog format, covering v0.1.0 through v0.2.4
- Add `Update CHANGELOG` step in `release.yml` — generates and prepends a new entry (Added/Fixed sections from conventional commits) on each release
- Include `CHANGELOG.md` in the version bump commit