### PR TITLE
[CI] Upgrade Node to 22 for Trusted Publishing support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 


### PR DESCRIPTION
Trusted Publishing requires npm CLI 11.5.1+ and Node 22.14.0+. The release workflow was using Node 20, causing `npm publish --provenance` to fail with 404.

- Upgrade `node-version` from `'20'` to `'22'` in `release.yml`