### PR TITLE
[CI] Upgrade Node to 24 (npm 11.x required for Trusted Publishing)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
 
       - run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 


### PR DESCRIPTION
Closes #41

Trusted Publishing requires npm >= 11.5.1. Node 22 ships with npm 10.x — Node 24 ships with npm 11.x, satisfying both requirements.

- Upgrade `node-version` from `'22'` to `'24'` in `release.yml` and `ci.yml`