### PR TITLE
[Context] Add typed context classes for all hook events

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,58 @@ hook.on('Elicitation', '*', (ctx) => {
 })
 ```
 
+### `ElicitationResultContext`
+
+```ts
+hook.on('ElicitationResult', '*', (ctx) => {
+  ctx.prompt  // the original elicitation prompt
+  ctx.result  // the user's answer
+})
+```
+
+### `StopFailureContext`
+
+```ts
+hook.on('StopFailure', '*', (ctx) => {
+  ctx.error  // error message describing what went wrong
+})
+```
+
+### `NotificationContext`
+
+```ts
+hook.on('Notification', '*', (ctx) => {
+  ctx.notificationType  // e.g. 'info' | 'warning' | 'error'
+  ctx.message           // notification text
+})
+```
+
+### `InstructionsLoadedContext`
+
+```ts
+hook.on('InstructionsLoaded', '*', (ctx) => {
+  ctx.reason  // why instructions were loaded
+  ctx.files   // list of loaded CLAUDE.md file paths
+})
+```
+
+### `TaskCreatedContext` / `TaskCompletedContext`
+
+```ts
+hook.on('TaskCreated', '*', (ctx) => {
+  ctx.taskId       // unique task identifier
+  ctx.description  // task description
+})
+```
+
+### `WorktreeCreateContext` / `WorktreeRemoveContext`
+
+```ts
+hook.on('WorktreeCreate', '*', (ctx) => {
+  ctx.worktreePath  // absolute path to the worktree
+})
+```
+
 For all other events, the handler receives a `GenericContext` with `ctx.block(reason)` and base properties.
 
 ## Supported events
@@ -252,13 +304,13 @@ For all other events, the handler receives a `GenericContext` with `ctx.block(re
 | `SessionStart` | Session begins or resumes | no | `SessionStartContext` |
 | `SessionEnd` | Session ends | no | `GenericContext` |
 | `Stop` | Claude finishes a turn | yes | `StopContext` |
-| `StopFailure` | Claude turn ended with error | no | `StopContext` |
+| `StopFailure` | Claude turn ended with error | no | `StopFailureContext` |
 | `SubagentStart` | Subagent spawned | no | `GenericContext` |
 | `SubagentStop` | Subagent finished | yes | `StopContext` |
-| `TaskCreated` | Task created | yes | `GenericContext` |
-| `TaskCompleted` | Task completed | yes | `GenericContext` |
-| `WorktreeCreate` | Git worktree created | yes | `GenericContext` |
-| `WorktreeRemove` | Git worktree removed | yes | `GenericContext` |
+| `TaskCreated` | Task created | yes | `TaskCreatedContext` |
+| `TaskCompleted` | Task completed | yes | `TaskCompletedContext` |
+| `WorktreeCreate` | Git worktree created | yes | `WorktreeCreateContext` |
+| `WorktreeRemove` | Git worktree removed | yes | `WorktreeRemoveContext` |
 | `FileChanged` | Watched file changed on disk | yes | `FileChangedContext` |
 | `CwdChanged` | Working directory changed | yes | `CwdChangedContext` |
 | `ConfigChange` | Claude Code config changed | yes | `GenericContext` |
@@ -266,9 +318,9 @@ For all other events, the handler receives a `GenericContext` with `ctx.block(re
 | `PreCompact` | Before context compaction | yes | `GenericContext` |
 | `PostCompact` | After context compaction | no | `GenericContext` |
 | `Elicitation` | Claude needs user input | yes | `ElicitationContext` |
-| `ElicitationResult` | Elicitation answer received | yes | `GenericContext` |
-| `InstructionsLoaded` | CLAUDE.md / rules loaded | no | `GenericContext` |
-| `Notification` | System notification | no | `GenericContext` |
+| `ElicitationResult` | Elicitation answer received | yes | `ElicitationResultContext` |
+| `InstructionsLoaded` | CLAUDE.md / rules loaded | no | `InstructionsLoadedContext` |
+| `Notification` | System notification | no | `NotificationContext` |
 
 ## Exit codes
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -8,10 +8,18 @@ import type {
   UserPromptExpansionEvent,
   SessionStartEvent,
   StopEvent,
+  StopFailureEvent,
   SubagentStopEvent,
   FileChangedEvent,
   CwdChangedEvent,
   ElicitationEvent,
+  ElicitationResultEvent,
+  NotificationEvent,
+  InstructionsLoadedEvent,
+  TaskCreatedEvent,
+  TaskCompletedEvent,
+  WorktreeCreateEvent,
+  WorktreeRemoveEvent,
   HookOutput,
   HookEventName,
   ToolInput,
@@ -245,6 +253,75 @@ export class ElicitationContext extends BaseContext {
     this._blocked = true
     this._blockReason = reason
   }
+}
+
+export class StopFailureContext extends BaseContext {
+  declare readonly event: StopFailureEvent
+
+  constructor(event: StopFailureEvent) { super(event) }
+
+  get error(): string { return this.event.error }
+}
+
+export class ElicitationResultContext extends BaseContext {
+  declare readonly event: ElicitationResultEvent
+
+  constructor(event: ElicitationResultEvent) { super(event) }
+
+  get prompt(): string { return this.event.prompt }
+  get result(): string { return this.event.result }
+}
+
+export class NotificationContext extends BaseContext {
+  declare readonly event: NotificationEvent
+
+  constructor(event: NotificationEvent) { super(event) }
+
+  get notificationType(): string { return this.event.notification_type }
+  get message(): string { return this.event.message }
+}
+
+export class InstructionsLoadedContext extends BaseContext {
+  declare readonly event: InstructionsLoadedEvent
+
+  constructor(event: InstructionsLoadedEvent) { super(event) }
+
+  get reason(): string { return this.event.reason }
+  get files(): string[] { return this.event.files }
+}
+
+export class TaskCreatedContext extends BaseContext {
+  declare readonly event: TaskCreatedEvent
+
+  constructor(event: TaskCreatedEvent) { super(event) }
+
+  get taskId(): string { return this.event.task_id }
+  get description(): string { return this.event.description }
+}
+
+export class TaskCompletedContext extends BaseContext {
+  declare readonly event: TaskCompletedEvent
+
+  constructor(event: TaskCompletedEvent) { super(event) }
+
+  get taskId(): string { return this.event.task_id }
+  get description(): string { return this.event.description }
+}
+
+export class WorktreeCreateContext extends BaseContext {
+  declare readonly event: WorktreeCreateEvent
+
+  constructor(event: WorktreeCreateEvent) { super(event) }
+
+  get worktreePath(): string { return this.event.worktree_path }
+}
+
+export class WorktreeRemoveContext extends BaseContext {
+  declare readonly event: WorktreeRemoveEvent
+
+  constructor(event: WorktreeRemoveEvent) { super(event) }
+
+  get worktreePath(): string { return this.event.worktree_path }
 }
 
 export class GenericContext extends BaseContext {

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -11,10 +11,18 @@ import type {
   UserPromptExpansionEvent,
   SessionStartEvent,
   StopEvent,
+  StopFailureEvent,
   SubagentStopEvent,
   FileChangedEvent,
   CwdChangedEvent,
   ElicitationEvent,
+  ElicitationResultEvent,
+  NotificationEvent,
+  InstructionsLoadedEvent,
+  TaskCreatedEvent,
+  TaskCompletedEvent,
+  WorktreeCreateEvent,
+  WorktreeRemoveEvent,
   BashToolInput,
   EditToolInput,
   WriteToolInput,
@@ -31,6 +39,14 @@ import {
   FileChangedContext,
   CwdChangedContext,
   ElicitationContext,
+  StopFailureContext,
+  ElicitationResultContext,
+  NotificationContext,
+  InstructionsLoadedContext,
+  TaskCreatedContext,
+  TaskCompletedContext,
+  WorktreeCreateContext,
+  WorktreeRemoveContext,
   GenericContext,
 } from './context.js'
 import { matchMatcher, getMatcherValue } from './router.js'
@@ -59,9 +75,10 @@ function createContext(event: AnyEvent): BaseContext {
     case 'UserPromptExpansion':
       return new UserPromptExpansionContext(event as UserPromptExpansionEvent)
     case 'Stop':
-    case 'StopFailure':
     case 'SubagentStop':
       return new StopContext(event as StopEvent | SubagentStopEvent)
+    case 'StopFailure':
+      return new StopFailureContext(event as StopFailureEvent)
     case 'SessionStart':
       return new SessionStartContext(event as SessionStartEvent)
     case 'FileChanged':
@@ -70,6 +87,20 @@ function createContext(event: AnyEvent): BaseContext {
       return new CwdChangedContext(event as CwdChangedEvent)
     case 'Elicitation':
       return new ElicitationContext(event as ElicitationEvent)
+    case 'ElicitationResult':
+      return new ElicitationResultContext(event as ElicitationResultEvent)
+    case 'Notification':
+      return new NotificationContext(event as NotificationEvent)
+    case 'InstructionsLoaded':
+      return new InstructionsLoadedContext(event as InstructionsLoadedEvent)
+    case 'TaskCreated':
+      return new TaskCreatedContext(event as TaskCreatedEvent)
+    case 'TaskCompleted':
+      return new TaskCompletedContext(event as TaskCompletedEvent)
+    case 'WorktreeCreate':
+      return new WorktreeCreateContext(event as WorktreeCreateEvent)
+    case 'WorktreeRemove':
+      return new WorktreeRemoveContext(event as WorktreeRemoveEvent)
     default:
       return new GenericContext(event)
   }
@@ -95,6 +126,14 @@ export class HookHandler {
   on(eventName: 'FileChanged', matcher: string, handler: Handler<FileChangedContext>): this
   on(eventName: 'CwdChanged', matcher: string, handler: Handler<CwdChangedContext>): this
   on(eventName: 'Elicitation', matcher: string, handler: Handler<ElicitationContext>): this
+  on(eventName: 'ElicitationResult', matcher: string, handler: Handler<ElicitationResultContext>): this
+  on(eventName: 'StopFailure', matcher: string, handler: Handler<StopFailureContext>): this
+  on(eventName: 'Notification', matcher: string, handler: Handler<NotificationContext>): this
+  on(eventName: 'InstructionsLoaded', matcher: string, handler: Handler<InstructionsLoadedContext>): this
+  on(eventName: 'TaskCreated', matcher: string, handler: Handler<TaskCreatedContext>): this
+  on(eventName: 'TaskCompleted', matcher: string, handler: Handler<TaskCompletedContext>): this
+  on(eventName: 'WorktreeCreate', matcher: string, handler: Handler<WorktreeCreateContext>): this
+  on(eventName: 'WorktreeRemove', matcher: string, handler: Handler<WorktreeRemoveContext>): this
   on(eventName: HookEventName, matcher: string, handler: Handler<GenericContext>): this
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   on(eventName: string, matcher: string, handler: (ctx: any) => void | Promise<void>): this {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,10 +7,18 @@ export {
   UserPromptSubmitContext,
   UserPromptExpansionContext,
   StopContext,
+  StopFailureContext,
   SessionStartContext,
   FileChangedContext,
   CwdChangedContext,
   ElicitationContext,
+  ElicitationResultContext,
+  NotificationContext,
+  InstructionsLoadedContext,
+  TaskCreatedContext,
+  TaskCompletedContext,
+  WorktreeCreateContext,
+  WorktreeRemoveContext,
   GenericContext,
 } from './context.js'
 export type {


### PR DESCRIPTION
Adds dedicated typed context classes for 8 hook events that previously fell through to `GenericContext`, making event-specific fields inaccessible without manual casting.

Key changes:
- `src/context.ts` — adds `StopFailureContext` (`error`), `ElicitationResultContext` (`prompt`, `result`), `NotificationContext` (`notificationType`, `message`), `InstructionsLoadedContext` (`reason`, `files`), `TaskCreatedContext` (`taskId`, `description`), `TaskCompletedContext` (`taskId`, `description`), `WorktreeCreateContext` (`worktreePath`), `WorktreeRemoveContext` (`worktreePath`)
- `src/hook.ts` — updates `createContext` switch to route each event to its new context class; adds 8 typed overloads on `HookHandler.on()` for full IDE inference without manual type annotations
- `src/index.ts` — exports all 8 new context classes
- `README.md` — adds context sections with usage examples; updates supported events table

Closes #45