### PR TITLE
[CI] Fetch full git history in release workflow to resolve tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.RELEASE_TOKEN }}
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
`actions/checkout@v4` defaults to `fetch-depth: 1`, so `git describe --tags` finds no tags and `LAST_TAG` stays empty — causing the CHANGELOG entry to be generated with no content.

Key changes:
- `.github/workflows/release.yml` — adds `fetch-depth: 0` to `actions/checkout` so the full tag history is available when generating the CHANGELOG

Closes #48